### PR TITLE
go: Remove unnecessary struct fields

### DIFF
--- a/examples/go/go-actor-full/main.go
+++ b/examples/go/go-actor-full/main.go
@@ -28,7 +28,6 @@ func init() {
 var total uint64
 
 type ComponentNameImpl struct {
-	total uint64
 }
 
 // Implementation of the exported interface

--- a/examples/go/go-actor-minimal/main.go
+++ b/examples/go/go-actor-minimal/main.go
@@ -13,7 +13,6 @@ func init() {
 var total uint64
 
 type ComponentNameImpl struct {
-    total uint64
 }
 
 // Implementation of the exported interface


### PR DESCRIPTION
The global state is already stored in a global variable, we do not need these struct fields