### PR TITLE
Don't Use Flags In Rust To Do List Example

### DIFF
--- a/examples/rust/rust-todo-list/src/lib.rs
+++ b/examples/rust/rust-todo-list/src/lib.rs
@@ -71,6 +71,18 @@ impl ExtensionsForUpdateItem for UpdateItem {
             || self.deadline.is_some()
     }
 }
+trait Ordinal {
+    fn ordinal(&self) -> u8;
+}
+impl Ordinal for Priority {
+    fn ordinal(&self) -> u8 {
+        match self {
+            Priority::Low => 0,
+            Priority::Medium => 1,
+            Priority::High => 2,
+        }
+    }
+}
 
 impl Guest for Component {
     fn add(item: NewItem) -> Result<Item, String> {
@@ -209,7 +221,7 @@ impl Guest for Component {
 
             match query.sort {
                 Some(QuerySort::Priority) => {
-                    result.sort_by_key(|item| cmp::Reverse(item.priority));
+                    result.sort_by_key(|item| cmp::Reverse(item.priority.ordinal()));
                 }
                 Some(QuerySort::Deadline) => {
                     result.sort_by_key(|item| cmp::Reverse(item.deadline));
@@ -231,7 +243,7 @@ impl Guest for Component {
                         .deadline
                         .and_then(|i: i64| NaiveDateTime::from_timestamp_opt(i, 0))
                         .map(|utc| {
-                            DateTime::<Utc>::from_utc(utc, Utc)
+                            DateTime::<Utc>::from_naive_utc_and_offset(utc, Utc)
                                 .format(DATE_TIME_FORMAT)
                                 .to_string()
                         })

--- a/examples/rust/rust-todo-list/wit/component-name.wit
+++ b/examples/rust/rust-todo-list/wit/component-name.wit
@@ -8,9 +8,7 @@ interface api {
     done,
   }
 
-  // Currently use `flags` type simply to gain the Ord typeclass instance.
-  // Once enum type derives Ord, switch to enum for more appropriate semantics.
-  flags priority {
+  enum priority {
     low,
     medium,
     high,


### PR DESCRIPTION
The usage of the flags data type does not match the intended semantics of priority and forces users to immediately work with a relatively esoteric WIT type when getting started. We can instead use an enumeration and simply define our own ordinal function for it.