### PR TITLE
Update repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://golem.cloud"
+repository = "https://github.com/golemcloud/golem-examples"
 description = "Golem example templates"
 
 [dependencies]


### PR DESCRIPTION
Update [repository](https://rust-digger.code-maven.com/about-repository) field in `Cargo.toml` to point to the GitHub repo.

This makes the location of the source code show correctly on Crates.io. 🙂

---

Same change as in https://github.com/golemcloud/golem-wit/pull/15, just missed this repository.