### PR TITLE
Typescript: update jco and cleanup npm scripts

### DIFF
--- a/examples/ts/INSTRUCTIONS
+++ b/examples/ts/INSTRUCTIONS
@@ -1,14 +1,12 @@
 Compile the TypeScript project with npm:
 ```bash
 npm install
-npm run build
+npm run componentize
 ```
 The `out/component_name.wasm` file is ready to be uploaded to Golem Cloud!
 
-To do stub generation run the following command:
-```bash
-npm run stub
-```
-
-This will generate the typescript declaration files in `src/interfaces`
-
+All npm run commands:
+  - stub: generates TypeScript mappings from the wit files
+  - build: compiles and bundles the TypeScript sources
+  - componentize: runs stub and build, then creates the wasm file for the component
+  - clean: "rm -rf out src/interfaces src/main.d.ts"

--- a/examples/ts/ts-actor-minimal/.gitignore
+++ b/examples/ts/ts-actor-minimal/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 out/
-src/interfaces/
+src/generated/
 src/main.d.ts
 src/main.js

--- a/examples/ts/ts-actor-minimal/metadata.json
+++ b/examples/ts/ts-actor-minimal/metadata.json
@@ -4,7 +4,7 @@
   "exclude": [
     "node_modules",
     "out",
-    "src/interfaces",
+    "src/generated",
     "src/main.d.ts",
     "src/main.js"
   ]

--- a/examples/ts/ts-actor-minimal/package.json
+++ b/examples/ts/ts-actor-minimal/package.json
@@ -1,18 +1,16 @@
 {
   "scripts": {
-    "stub": "jco transpile wit --name main --no-namespaced-exports --stub --out-dir src && rm -rf src/main.js",
-    "buildTs": "rollup --config",
-    "checkTs": "tsc",
-    "buildWasm": "jco componentize -w wit -o out/component_name.wasm out/main.js",
-    "build": "npm run stub && npm run checkTs && npm run buildTs && npm run buildWasm",
+    "stub": "jco stubgen wit -o src/generated",
+    "build": "rollup --config",
+    "componentize": "npm run stub && npm run build && jco componentize -w wit -o out/component_name.wasm out/main.js",
     "clean": "rm -rf out src/interfaces src/main.d.ts"
   },
   "devDependencies": {
     "@golemcloud/componentize-js": "0.8.3-golem.3",
     "@golemcloud/golem-ts": "0.1.0",
-    "@golemcloud/jco": "1.2.4-golem.3",
+    "@golemcloud/jco": "1.2.4-golem.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-typescript": "^11.1.6",
+    "rollup-plugin-typescript2": "^0.36.0",
     "@types/node": "^20.14.2",
     "rollup": "^4.18.0",
     "tslib": "^2.6.3"

--- a/examples/ts/ts-actor-minimal/rollup.config.mjs
+++ b/examples/ts/ts-actor-minimal/rollup.config.mjs
@@ -1,4 +1,4 @@
-import typescript from "@rollup/plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 import resolve from "@rollup/plugin-node-resolve";
 
 export default {

--- a/examples/ts/ts-actor-minimal/src/main.ts
+++ b/examples/ts/ts-actor-minimal/src/main.ts
@@ -1,8 +1,8 @@
-import { PackNameApi } from './interfaces/pack-name-api.js';
+import { Api } from './generated/component-name.js';
 
 let state = BigInt(0);
 
-export const api: typeof PackNameApi = {
+export const api: Api = {
     add(value: bigint) {
         console.log(`Adding ${value} to the counter`);
         state += value;

--- a/examples/ts/ts-fetch-example/.gitignore
+++ b/examples/ts/ts-fetch-example/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 out/
-src/interfaces/
+src/generated/
 src/main.d.ts
 src/main.js

--- a/examples/ts/ts-fetch-example/metadata.json
+++ b/examples/ts/ts-fetch-example/metadata.json
@@ -6,7 +6,7 @@
   "exclude": [
     "node_modules",
     "out",
-    "src/interfaces",
+    "src/generated",
     "src/main.d.ts",
     "src/main.js"
   ]

--- a/examples/ts/ts-fetch-example/package.json
+++ b/examples/ts/ts-fetch-example/package.json
@@ -1,18 +1,16 @@
 {
   "scripts": {
-    "stub": "jco transpile wit --name main --no-namespaced-exports --stub --out-dir src && rm -rf src/main.js",
-    "buildTs": "rollup --config",
-    "checkTs": "tsc",
-    "buildWasm": "jco componentize -w wit -o out/component_name.wasm out/main.js",
-    "build": "npm run stub && npm run checkTs && npm run buildTs && npm run buildWasm",
+    "stub": "jco stubgen wit -o src/generated",
+    "build": "rollup --config",
+    "componentize": "npm run stub && npm run build && jco componentize -w wit -o out/component_name.wasm out/main.js",
     "clean": "rm -rf out src/interfaces src/main.d.ts"
   },
   "devDependencies": {
     "@golemcloud/componentize-js": "0.8.3-golem.3",
     "@golemcloud/golem-ts": "0.1.0",
-    "@golemcloud/jco": "1.2.4-golem.3",
+    "@golemcloud/jco": "1.2.4-golem.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-typescript": "^11.1.6",
+    "rollup-plugin-typescript2": "^0.36.0",
     "@types/node": "^20.14.2",
     "rollup": "^4.18.0",
     "tslib": "^2.6.3"

--- a/examples/ts/ts-fetch-example/rollup.config.mjs
+++ b/examples/ts/ts-fetch-example/rollup.config.mjs
@@ -1,4 +1,4 @@
-import typescript from "@rollup/plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 import resolve from "@rollup/plugin-node-resolve";
 
 export default {

--- a/examples/ts/ts-fetch-example/src/main.ts
+++ b/examples/ts/ts-fetch-example/src/main.ts
@@ -1,9 +1,9 @@
 import {asyncToSyncAsResult} from "@golemcloud/golem-ts";
-import { PackNameApi } from './interfaces/pack-name-api';
+import { Api } from './generated/component-name';
 
 let result: any
 
-export const api: typeof PackNameApi = {
+export const api: Api = {
     getLastResult(): string {
         return JSON.stringify(result);
     },


### PR DESCRIPTION
- updates the used jco version and uses the new stub generator
- some cleanups on the npm run scripts