### PR TITLE
build.rs: make WIT root configurable with an env-var

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let golem_wit_root = PathBuf::from(find_package_root("golem-wit"));
+    let golem_wit_root = PathBuf::from(
+        env::var("GOLEM_WIT_ROOT").unwrap_or_else(|_| find_package_root("golem-wit")),
+    );
 
     println!("cargo:warning=Output dir: {out_dir:?}");
     println!("cargo:warning=Golem WIT root: {golem_wit_root:?}");


### PR DESCRIPTION
In a sandboxed build environment, `cargo metadata` tries to query crates.io. Even though I have been trying to pass `--offline` or `frozen`, I ran into an exception:
```
golem>   thread 'main' panicked at /build/cargo-vendor-dir/golem-examples-1.0.4/build.rs:30:10:
golem>   called `Result::unwrap()` on an `Err` value: CargoMetadata { stderr: "warning: `/build/cargo-vendor-dir/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
warning: `/build/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
error: failed to get `Inflector` as a dependency of package `golem-examples v1.0.4 (/build/cargo-vendor-dir/golem-examples-1.0.4)`

Caused by:
  failed to load source for dependency `Inflector`

Caused by:
  Unable to update registry `crates-io`
Caused by:
  failed to update replaced source registry `crates-io`

Caused by:
  failed to read root of directory source: /build/cargo-vendor-dir/cargo-vendor-dir

Caused by:
  No such file or directory (os error 2)
" }
```
I want to propose a way to inject the location of the crate by setting an environment variable. If the environment variable is not set, we default to use `cargo metadata`

An analogous solution was implemented for golem-wasm-rpc: https://github.com/golemcloud/wasm-rpc/pull/79